### PR TITLE
Add aarch64

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.bug.yml
+++ b/.github/ISSUE_TEMPLATE/issue.bug.yml
@@ -52,6 +52,7 @@ body:
       label: CPU architecture
       options:
         - x86-64
+        - arm64
     validations:
       required: true
   - type: textarea

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:debiantrixie
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-debiantrixie
 
 # set version label
 ARG BUILD_DATE
@@ -34,7 +34,7 @@ RUN \
   cd /tmp && \
   curl -o \
     /tmp/rawtherapee.app -L \
-    "https://github.com/RawTherapee/RawTherapee/releases/download/${RAWTHERAPEE_VERSION}/RawTherapee_${RAWTHERAPEE_VERSION}_x86_64_release.AppImage" && \
+    "https://github.com/RawTherapee/RawTherapee/releases/download/${RAWTHERAPEE_VERSION}/RawTherapee_${RAWTHERAPEE_VERSION}_arm64_release.AppImage" && \
   chmod +x /tmp/rawtherapee.app && \
   ./rawtherapee.app --appimage-extract && \
   mv squashfs-root /opt/rawtherapee && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DEV_DOCKERHUB_IMAGE = 'lsiodev/rawtherapee'
     PR_DOCKERHUB_IMAGE = 'lspipepr/rawtherapee'
     DIST_IMAGE = 'ubuntu'
-    MULTIARCH = 'false'
+    MULTIARCH = 'true'
     CI = 'true'
     CI_WEB = 'true'
     CI_PORT = '3001'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
     CI_PORT = '3001'
     CI_SSL = 'true'
     CI_DELAY = '120'
+    CI_WEB_SCREENSHOT_DELAY = '30'
     CI_DOCKERENV = ''
     CI_AUTH = ''
     CI_WEBPATH = ''
@@ -903,6 +904,7 @@ pipeline {
                 --shm-size=1gb \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -e IMAGE=\"${IMAGE}\" \
+                -e WEB_SCREENSHOT_DELAY=\"${CI_WEB_SCREENSHOT_DELAY}\" \
                 -e DOCKER_LOGS_TIMEOUT=\"${CI_DELAY}\" \
                 -e TAGS=\"${CI_TAGS}\" \
                 -e META_TAG=\"${META_TAG}\" \

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The architectures supported by this image are:
 | Architecture | Available | Tag |
 | :----: | :----: | ---- |
 | x86-64 | ✅ | amd64-\<version tag\> |
-| arm64 | ❌ | |
+| arm64 | ✅ | arm64v8-\<version tag\> |
 
 ## Application Setup
 
@@ -586,6 +586,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **26.07.26:** - Add aarch64 support.
 * **04.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **28.12.25:** - Add Wayland init logic.
 * **22.09.25:** - Rebase to Debian Trixie.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -23,6 +23,7 @@ repo_vars:
   - CI_PORT = '3001'
   - CI_SSL = 'true'
   - CI_DELAY = '120'
+  - CI_WEB_SCREENSHOT_DELAY = '30'
   - CI_DOCKERENV = ''
   - CI_AUTH = ''
   - CI_WEBPATH = ''

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -17,7 +17,7 @@ repo_vars:
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/rawtherapee'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/rawtherapee'
   - DIST_IMAGE = 'ubuntu'
-  - MULTIARCH = 'false'
+  - MULTIARCH = 'true'
   - CI = 'true'
   - CI_WEB = 'true'
   - CI_PORT = '3001'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -11,6 +11,7 @@ project_blurb_optional_extras_enabled: false
 # supported architectures
 available_architectures:
   - {arch: "{{ arch_x86_64 }}", tag: "latest"}
+  - {arch: "{{ arch_arm64 }}", tag: "arm64v8-latest"}
 # container parameters
 common_param_env_vars_enabled: true
 param_container_name: "{{ project_name }}"
@@ -103,6 +104,7 @@ init_diagram: |
   "rawtherapee:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "26.07.26:", desc: "Add aarch64 support."}
   - {date: "04.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}


### PR DESCRIPTION
They release multi arch appimages now, this adds aarch64 and fixes the ingestion URL. 

Manual test on aarch64: 

<img width="1358" height="783" alt="raw" src="https://github.com/user-attachments/assets/6cff8773-1c81-4876-9b1e-2f341c37d86e" />
